### PR TITLE
 Fix #24 -- Pass all events, tooltips, popups from FeatureGroups to markers

### DIFF
--- a/example/geojson-event.html
+++ b/example/geojson-event.html
@@ -1,0 +1,118 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+        <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
+        <script src="../src/L.Deflate.js"></script>
+        <style>
+            #map {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                right: 0;
+            }
+        </style>
+    </head>
+
+    <div id="map"></div>
+
+    <script>
+
+    window.onload = function () {
+        var map = L.map("map").setView([51.550406, -0.140765], 16);
+
+        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        var features = L.deflate({minSize: 20});
+        features.addTo(map);
+
+        var json = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": {
+                    "id": 1
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.144624, 51.551088],
+                            [-0.143648, 51.550818],
+                            [-0.143718, 51.550701],
+                            [-0.142398, 51.550351],
+                            [-0.142060, 51.550861],
+                            [-0.143160, 51.551155],
+                            [-0.143213, 51.551091],
+                            [-0.144410, 51.551408]
+                        ]
+                    ]
+                }
+            }, {
+                "type": "Feature",
+                "properties": {
+                    "id": 4
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.140574, 51.550509],
+                            [-0.140622, 51.550221],
+                            [-0.140456, 51.550208],
+                            [-0.140156, 51.550154],
+                            [-0.140113, 51.550316]
+                        ]
+                    ]
+                }
+            }, {
+                "type": "Feature",
+                "properties": {
+                    "id": 2
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        -0.140765, 51.550406
+                    ]
+                }
+            }, {
+                "type": "Feature",
+                "properties": {
+                    "id": 3
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.140620, 51.550216],
+                            [-0.140695, 51.549754],
+                            [-0.140290, 51.549702],
+                            [-0.140282, 51.549781],
+                            [-0.140475, 51.549807],
+                            [-0.140478, 51.549849],
+                            [-0.140255, 51.549824],
+                            [-0.140196, 51.550117],
+                            [-0.140290, 51.550127],
+                            [-0.140319, 51.550056],
+                            [-0.140488, 51.550084],
+                            [-0.140488, 51.550206],
+                            [-0.140620, 51.550216]
+                        ]
+                    ]
+                }
+            }]
+        };
+
+        var layer = L.geoJson(json, {style: {color: '#0000FF'}})
+        layer.on('click', function(e) {
+            console.log(e);
+            alert('Yes, you clicked.')
+        });
+        layer.addTo(features);
+    }
+    </script>
+
+</html>

--- a/example/geojson-two-layers-popup.html
+++ b/example/geojson-two-layers-popup.html
@@ -1,0 +1,119 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+        <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
+        <script src="../src/L.Deflate.js"></script>
+        <style>
+            #map {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                right: 0;
+            }
+        </style>
+    </head>
+
+    <div id="map"></div>
+
+    <script>
+
+    window.onload = function () {
+        var map = L.map("map").setView([51.550406, -0.140765], 16);
+
+        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        var features = L.deflate({minSize: 20});
+        features.addTo(map);
+
+        var buildings = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": {
+                    "id": 1
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.144624, 51.551088],
+                            [-0.143648, 51.550818],
+                            [-0.143718, 51.550701],
+                            [-0.142398, 51.550351],
+                            [-0.142060, 51.550861],
+                            [-0.143160, 51.551155],
+                            [-0.143213, 51.551091],
+                            [-0.144410, 51.551408]
+                        ]
+                    ]
+                }
+            }, {
+                "type": "Feature",
+                "properties": {
+                    "id": 3
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.140620, 51.550216],
+                            [-0.140695, 51.549754],
+                            [-0.140290, 51.549702],
+                            [-0.140282, 51.549781],
+                            [-0.140475, 51.549807],
+                            [-0.140478, 51.549849],
+                            [-0.140255, 51.549824],
+                            [-0.140196, 51.550117],
+                            [-0.140290, 51.550127],
+                            [-0.140319, 51.550056],
+                            [-0.140488, 51.550084],
+                            [-0.140488, 51.550206],
+                            [-0.140620, 51.550216]
+                        ]
+                    ]
+                }
+            }]
+        };
+
+        L.geoJson(buildings, {style: {color: '#FF0000'}}).bindPopup('buildings').addTo(features);
+
+        var transport = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": {
+                    "id": 4
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.140574, 51.550509],
+                            [-0.140622, 51.550221],
+                            [-0.140456, 51.550208],
+                            [-0.140156, 51.550154],
+                            [-0.140113, 51.550316]
+                        ]
+                    ]
+                }
+            }, {
+                "type": "Feature",
+                "properties": {
+                    "id": 2
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        -0.140765, 51.550406
+                    ]
+                }
+            }, ]
+        };
+        L.geoJson(transport, {style: {color: '#0000FF'}}).bindPopup('transport').addTo(map);
+    }
+    </script>
+
+</html>

--- a/example/geojson-two-layers-tooltip.html
+++ b/example/geojson-two-layers-tooltip.html
@@ -1,0 +1,119 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+        <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
+        <script src="../src/L.Deflate.js"></script>
+        <style>
+            #map {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                right: 0;
+            }
+        </style>
+    </head>
+
+    <div id="map"></div>
+
+    <script>
+
+    window.onload = function () {
+        var map = L.map("map").setView([51.550406, -0.140765], 16);
+
+        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        var features = L.deflate({minSize: 20});
+        features.addTo(map);
+
+        var buildings = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": {
+                    "id": 1
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.144624, 51.551088],
+                            [-0.143648, 51.550818],
+                            [-0.143718, 51.550701],
+                            [-0.142398, 51.550351],
+                            [-0.142060, 51.550861],
+                            [-0.143160, 51.551155],
+                            [-0.143213, 51.551091],
+                            [-0.144410, 51.551408]
+                        ]
+                    ]
+                }
+            }, {
+                "type": "Feature",
+                "properties": {
+                    "id": 3
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.140620, 51.550216],
+                            [-0.140695, 51.549754],
+                            [-0.140290, 51.549702],
+                            [-0.140282, 51.549781],
+                            [-0.140475, 51.549807],
+                            [-0.140478, 51.549849],
+                            [-0.140255, 51.549824],
+                            [-0.140196, 51.550117],
+                            [-0.140290, 51.550127],
+                            [-0.140319, 51.550056],
+                            [-0.140488, 51.550084],
+                            [-0.140488, 51.550206],
+                            [-0.140620, 51.550216]
+                        ]
+                    ]
+                }
+            }]
+        };
+
+        L.geoJson(buildings, {style: {color: '#FF0000'}}).bindTooltip('buildings').bindPopup('Popup').addTo(features);
+
+        var transport = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": {
+                    "id": 4
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.140574, 51.550509],
+                            [-0.140622, 51.550221],
+                            [-0.140456, 51.550208],
+                            [-0.140156, 51.550154],
+                            [-0.140113, 51.550316]
+                        ]
+                    ]
+                }
+            }, {
+                "type": "Feature",
+                "properties": {
+                    "id": 2
+                },
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        -0.140765, 51.550406
+                    ]
+                }
+            }, ]
+        };
+        L.geoJson(transport, {style: {color: '#0000FF'}}).bindTooltip('transport').addTo(map);
+    }
+    </script>
+
+</html>

--- a/example/simple-tooltip.html
+++ b/example/simple-tooltip.html
@@ -1,0 +1,83 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+        <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet-src.js"></script>
+        <script src="../src/L.Deflate.js"></script>
+        <style>
+            #map {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                right: 0;
+            }
+        </style>
+    </head>
+
+    <div id="map"></div>
+
+    <script>
+
+    window.onload = function () {
+        var map = L.map("map").setView([51.550406, -0.140765], 16);
+
+        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        var features = L.deflate({minSize: 20});
+        features.addTo(map);
+
+        L.polygon([
+            [51.551088, -0.144624],
+            [51.550818, -0.143648],
+            [51.550701, -0.143718],
+            [51.550351, -0.142398],
+            [51.550861, -0.142060],
+            [51.551155, -0.143160],
+            [51.551091, -0.143213],
+            [51.551408, -0.144410]
+        ])
+        .bindTooltip('UPS')
+        .addTo(features);
+
+        L.polygon([
+            [51.550509, -0.140574],
+            [51.550221, -0.140622],
+            [51.550208, -0.140456],
+            [51.550154, -0.140156],
+            [51.550316, -0.140113],
+        ])
+        .bindTooltip('Kentish Town Station')
+        .addTo(features);
+
+        L.polygon([
+            [51.550216, -0.140620],
+            [51.549754, -0.140695],
+            [51.549702, -0.140290],
+            [51.549781, -0.140282],
+            [51.549807, -0.140475],
+            [51.549849, -0.140478],
+            [51.549824, -0.140255],
+            [51.550117, -0.140196],
+            [51.550127, -0.140290],
+            [51.550056, -0.140319],
+            [51.550084, -0.140488],
+            [51.550206, -0.140488],
+            [51.550216, -0.140620]
+        ])
+        .bindTooltip('Wahaca')
+        .addTo(features);
+
+        var polyline = L.polyline([
+            [51.550836, -0.140684],
+            [51.550499, -0.140767],
+            [51.550021, -0.140834],
+            [51.549684, -0.140891]
+        ], {color: 'red'}).addTo(features);
+
+        var marker = L.marker([51.550406, -0.140765]).addTo(features);
+    }
+    </script>
+
+</html>

--- a/tests/test.js
+++ b/tests/test.js
@@ -254,6 +254,46 @@ describe('Leaflet.Deflate', function() {
     });
 
     describe('Events', function () {
+        var json = {
+            "type": "FeatureCollection",
+            "features": [{
+                "type": "Feature",
+                "properties": {
+                    "id": 1
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.273284912109375, 51.60437164681676],
+                            [-0.30212402343749994, 51.572802100290254],
+                            [-0.276031494140625, 51.57194856482396],
+                            [-0.267791748046875, 51.587309751245456],
+                            [-0.273284912109375, 51.60437164681676]
+                        ]
+                    ]
+                }
+            },
+            {
+                "type": "Feature",
+                "properties": {
+                    "id": 4
+                },
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [
+                            [-0.25543212890625, 51.600959780448626],
+                            [-0.2581787109375, 51.57621608189101],
+                            [-0.22247314453125, 51.6001067737997],
+                            [-0.24032592773437497, 51.613752957501],
+                            [-0.25543212890625, 51.600959780448626]
+                        ]
+                    ]
+                }
+            }]
+        };
+
         it('passes event listeners to marker', function () {
             l = L.deflate({minSize: 20}).addTo(map);
             var callback = function() {}
@@ -268,6 +308,82 @@ describe('Leaflet.Deflate', function() {
 
             polygon.marker._events.should.have.property('click');
             polygon.marker._events['click'][0].fn.should.equal(callback);
+        });
+
+        it('passes popup to marker', function () {
+            l = L.deflate({minSize: 20}).addTo(map);
+            var callback = function() {}
+            
+            polygon = L.polygon([
+                [51.509, -0.08],
+                [51.503, -0.06],
+                [51.51, -0.047]
+            ]);
+            polygon.bindPopup('Click');
+            polygon.addTo(l);
+
+            polygon.marker._popupHandlersAdded.should.equal(true);
+            polygon.marker._popup._content.should.equal('Click');
+        });
+
+        it('passes tooltip to marker', function () {
+            l = L.deflate({minSize: 20}).addTo(map);
+            var callback = function() {}
+            
+            polygon = L.polygon([
+                [51.509, -0.08],
+                [51.503, -0.06],
+                [51.51, -0.047]
+            ]);
+            polygon.bindTooltip('Click');
+            polygon.addTo(l);
+
+            polygon.marker._tooltipHandlersAdded.should.equal(true);
+            polygon.marker._tooltip._content.should.equal('Click');
+        });
+
+        it('passes events from GeoJSON to marker', function () {
+            l = L.deflate({minSize: 20}).addTo(map);
+            var callback = function() {}
+
+            L.geoJson(json).on('click', callback).addTo(l);
+
+            map.eachLayer(function (layer) {
+                if (layer.marker) {
+                    layer.marker._events.should.have.property('click');
+                    layer.marker._events['click'][0].fn.should.equal(callback);
+                }
+            });
+        });
+
+        it('passes popup from GeoJSON to marker', function () {
+            l = L.deflate({minSize: 20}).addTo(map);
+
+            L.geoJson(json).bindPopup('Click').addTo(l);
+
+            map.eachLayer(function (layer) {
+                if (layer.marker) {
+                    layer._popupHandlersAdded.should.equal(true);
+                    layer._popup._content.should.equal('Click');
+                    layer.marker._popupHandlersAdded.should.equal(true);
+                    layer.marker._popup._content.should.equal('Click');
+                }
+            });
+        });
+
+        it('passes tooltip from GeoJSON to marker', function () {
+            l = L.deflate({minSize: 20}).addTo(map);
+
+            L.geoJson(json).bindTooltip('Click').addTo(l);
+
+            map.eachLayer(function (layer) {
+                if (layer.marker) {
+                    layer._tooltipHandlersAdded.should.equal(true);
+                    layer._tooltip._content.should.equal('Click');
+                    layer.marker._tooltipHandlersAdded.should.equal(true);
+                    layer.marker._tooltip._content.should.equal('Click');
+                }
+            });
         });
     });
 


### PR DESCRIPTION
- Make sure all events, popups, and tooltips are passed from original layer to markers. 
- Make sure all events, popups, and tooltips bound to parent `FeatureGroups` are passed from original layer to markers. 

--- 

@petrovnn, if you have time, could you apply the [changed source](https://github.com/oliverroick/Leaflet.Deflate/blob/bug/tooltip-bindings/src/L.Deflate.js) to your project and let me know if that works for you? Cheers!