### PR TITLE
Add markerLayer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,9 @@ Option          | Type      | Default | Description
 `minSize`       | `int`     | `20`    | Optional. Defines the minimum width and height in pixels for a path to be displayed in its actual shape. Anything smaller than the defined `minSize` will be deflated.
 `markerType`    | `object`  | `L.marker` | Optional. Specifies the marker type to use for deflated features. Must be either `L.marker` or `L.circleMarker`.
 `markerOptions` | `object` or `function`  | `{}`    | Optional. Customize the markers of deflated features using [Leaflet marker options](http://leafletjs.com/reference-1.3.0.html#marker). If you specify `L.circleMarker` as `markerType` use [Leaflet circleMarker options](https://leafletjs.com/reference-1.3.0.html#circlemarker) instead.
-`markerCluster` | `boolean` | `false` | Indicates whether markers should be clustered. Requires [`Leaflet.MarkerCluser`](https://github.com/Leaflet/Leaflet.markercluster).
-`markerClusterOptions` | `object` | `{}`    | Optional. Customize the appearance and behaviour of clustered markers using [`Leaflet.markercluster` options](https://github.com/Leaflet/Leaflet.markercluster#options).
+`markerLayer`   | `L.featureGroup` | `L.featureGroup` | A `L.FeatureGroup` instance used to display deflate markers. Use this to realise special behaviours, such as clustering markers.
+`markerCluster` | `boolean` | `false` | Indicates whether markers should be clustered. Requires [`Leaflet.MarkerCluser`](https://github.com/Leaflet/Leaflet.markercluster). **Note:** This option is deprecated and will be removed with the next major release. Use the `markerLayer` option to inject a `MarkerClusterGroup` instance.
+`markerClusterOptions` | `object` | `{}`    | Optional. Customize the appearance and behaviour of clustered markers using [`Leaflet.markercluster` options](https://github.com/Leaflet/Leaflet.markercluster#options). **Note:** This option is deprecated and will be removed with the next major release. Use the `markerLayer` option to inject a `MarkerClusterGroup` instance.
 
 ## Examples
 
@@ -235,12 +236,13 @@ features.addTo(map);
 Using [Leaflet.Markercluster](https://github.com/Leaflet/Leaflet.markercluster>), you can cluster markers. To enable clustered markers on a map:
 
 1. Add the `Leaflet.Markercluster` libraries to the `head` section of your document as [described in the MarkerCluster documentation](https://github.com/Leaflet/Leaflet.markercluster#using-the-plugin>).
-2. Enable clustering by adding `markerCluster: true` to the options when initializing `L.deflate`.
+2. Inject a `MarkerClusterGroup` instance via the `markerLayer` option when initializing `L.deflate`.
 
 ```javascript
 const map = L.map("map").setView([51.505, -0.09], 12);
 
-const deflate_features = L.deflate({minSize: 20, markerCluster: true});
+const markerLayer = L.markerClusterGroup();
+const deflate_features = L.deflate({minSize: 20, markerLayer: markerLayer});
 deflate_features.addTo(map);
 
 const polygon = L.polygon([

--- a/example/markercluster-freezable.html
+++ b/example/markercluster-freezable.html
@@ -1,0 +1,96 @@
+<html>
+    <head>
+        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css" />
+        <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
+        <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
+        <script src="https://unpkg.com/leaflet@1.2.0/dist/leaflet.js"></script>
+        <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+        <script src="https://unpkg.com/leaflet.markercluster.freezable@1.0.0/dist/leaflet.markercluster.freezable.js"></script>
+
+        <script src="../src/L.Deflate.js"></script>
+        <style>
+            #map {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                left: 0;
+                right: 0;
+            }
+        </style>
+    </head>
+
+    <div id="map"></div>
+
+    <script>
+
+    window.onload = function () {
+        var map = L.map("map").setView([51.550406, -0.140765], 16);
+
+        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+
+        var layer = L.markerClusterGroup();
+        var features = L.deflate({minSize: 20, markerLayer: layer});
+        features.addTo(map);
+
+        L.polygon([
+            [51.551088, -0.144624],
+            [51.550818, -0.143648],
+            [51.550701, -0.143718],
+            [51.550351, -0.142398],
+            [51.550861, -0.142060],
+            [51.551155, -0.143160],
+            [51.551091, -0.143213],
+            [51.551408, -0.144410]
+        ])
+        .bindPopup('UPS')
+        .addTo(features);
+
+        L.polygon([
+            [51.550509, -0.140574],
+            [51.550221, -0.140622],
+            [51.550208, -0.140456],
+            [51.550154, -0.140156],
+            [51.550316, -0.140113],
+        ])
+        .bindPopup('Kentish Town Station')
+        .addTo(features);
+
+        L.polygon([
+            [51.550216, -0.140620],
+            [51.549754, -0.140695],
+            [51.549702, -0.140290],
+            [51.549781, -0.140282],
+            [51.549807, -0.140475],
+            [51.549849, -0.140478],
+            [51.549824, -0.140255],
+            [51.550117, -0.140196],
+            [51.550127, -0.140290],
+            [51.550056, -0.140319],
+            [51.550084, -0.140488],
+            [51.550206, -0.140488],
+            [51.550216, -0.140620]
+        ])
+        .bindPopup('Wahaca')
+        .addTo(features);
+
+        var polyline = L.polyline([
+            [51.550836, -0.140684],
+            [51.550499, -0.140767],
+            [51.550021, -0.140834],
+            [51.549684, -0.140891]
+        ], {color: 'red'}).addTo(features);
+        
+        L.marker([51.550406, -0.140765]).addTo(features);
+        L.marker([51.551406, -0.141765]).addTo(features);
+        L.marker([51.550406, -0.142765]).addTo(features);
+        L.marker([51.551406, -0.143765]).addTo(features);
+        L.marker([51.550406, -0.144765]).addTo(features);
+        L.marker([51.551406, -0.145765]).addTo(features);
+        L.marker([51.550406, -0.146765]).addTo(features);
+        L.marker([51.551406, -0.147765]).addTo(features);
+        layer.freezeAtZoom(15);
+    }
+    </script>
+</html>

--- a/example/markercluster-geojson.html
+++ b/example/markercluster-geojson.html
@@ -29,7 +29,8 @@
             attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map);
 
-        var features = L.deflate({minSize: 20, markerCluster: true});
+        var layer = L.markerClusterGroup();
+        var features = L.deflate({minSize: 20, markerLayer: layer});
         features.addTo(map);
 
         var json = {

--- a/example/markercluster.html
+++ b/example/markercluster.html
@@ -29,7 +29,8 @@
             attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map);
 
-        var features = L.deflate({minSize: 20, markerCluster: true});
+        var layer = L.markerClusterGroup();
+        var features = L.deflate({minSize: 20, markerLayer: layer});
         features.addTo(map);
 
         L.polygon([

--- a/src/L.Deflate.js
+++ b/src/L.Deflate.js
@@ -13,9 +13,20 @@ L.Deflate = L.FeatureGroup.extend({
     L.Util.setOptions(this, options);
     this._layers = [];
     this._needsPrepping = [];
-    this._featureLayer = (options.markerCluster
-      ? L.markerClusterGroup(this.options.markerClusterOptions)
-      : L.featureGroup(options));
+    this._featureLayer = this._getFeatureLayer(options);
+  },
+
+  _getFeatureLayer: function () {
+    if (this.options.markerLayer) {
+      return this.options.markerLayer;
+    }
+
+    if (this.options.markerCluster) {
+      console.warn('The options markerCluster and markerClusterOptions will be removed in the next major version of Leaflet.Deflate. Use the markerLayer option to inject a MarkerClusterGroup instance.'); // eslint-disable-line no-console
+      return L.markerClusterGroup(this.options.markerClusterOptions);
+    }
+
+    return L.featureGroup(this.options);
   },
 
   _getBounds: function (path) {

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -1,5 +1,6 @@
 import * as L from 'leaflet';
 import 'L.Deflate';
+import 'leaflet.markercluster';
 
 const l = L.deflate({minSize: 20});
 
@@ -85,3 +86,12 @@ L.deflate({
   markerCluster: true
 });
 
+
+// Layer Injection
+L.deflate({
+  markerLayer: L.featureGroup()
+});
+
+L.deflate({
+  markerLayer: L.markerClusterGroup()
+});

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,6 +12,7 @@ declare module 'leaflet' {
         markerOptions?: MarkerOptions | CircleMarkerOptions | MarkerOptionsFunction;
         markerClusterOptions?: MarkerClusterGroupOptions;
         markerType?: MarkerFactory | CircleMarkerFactory;
+        markerLayer?: FeatureGroup;
     }
 
     class DeflateLayer extends FeatureGroup {


### PR DESCRIPTION
**Describe the change**

Adds a new option `markerLayer` to allow to specify what `FeatureGroup` instance to use to display deflated markers. This can be used for clustering markers using Leaflet.Markercluster. 

**Checklist**

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have made added neccessary changes to the TypeScript declaration (if appropriate)
- [x] I have added necessary documentation (if appropriate)
