### PR TITLE
fix: Layer.remove() removes deflate marker (#134)

### DIFF
--- a/src/L.Deflate.js
+++ b/src/L.Deflate.js
@@ -1,5 +1,13 @@
 'use strict';
 
+L.Layer.include({
+  _originalRemove: L.Layer.prototype.remove,
+  remove: function () {
+    if (this.marker) { this.marker.remove(); }
+    return this._originalRemove();
+  },
+});
+
 L.Deflate = L.FeatureGroup.extend({
   options: {
     minSize: 10,

--- a/tests/L.Deflate.test.js
+++ b/tests/L.Deflate.test.js
@@ -120,7 +120,7 @@ const tests = (options) => () => {
       expect(map.hasLayer(polygon.marker)).toBeFalsy();
     });
 
-    test.skip('Layer.remove() removes marker', () => {
+    test('Layer.remove() removes polygon marker', () => {
       map.setZoom(10, { animate: false });
       polygon.remove();
       expect(map.hasLayer(polygon)).toBeFalsy();


### PR DESCRIPTION
**Describe the change**

Adds a mixin to L.Layer, which overwrites `remove` method to ensure the layer's marker is removed if it exists. 

**Checklist**

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made added necessary changes to the TypeScript declaration (if appropriate)
- [ ] I have added necessary documentation (if appropriate)
