### PR TITLE
fix: Map.remove(Layer) removes deflate marker (#133)

### DIFF
--- a/src/L.Deflate.js
+++ b/src/L.Deflate.js
@@ -8,6 +8,14 @@ L.Layer.include({
   },
 });
 
+L.Map.include({
+  _originalRemoveLayer: L.Map.prototype.removeLayer,
+  removeLayer: function (layer) {
+    if (layer.marker) { layer.marker.remove(); }
+    return this._originalRemoveLayer(layer);
+  },
+});
+
 L.Deflate = L.FeatureGroup.extend({
   options: {
     minSize: 10,

--- a/tests/L.Deflate.test.js
+++ b/tests/L.Deflate.test.js
@@ -92,7 +92,7 @@ const tests = (options) => () => {
       expect(map.hasLayer(polygon.marker)).toBeFalsy();
     });
 
-    test.skip('Map.removeLayer(Layer) removes marker', () => {
+    test('Map.removeLayer(Layer) removes marker', () => {
       map.setZoom(10, { animate: false });
       map.removeLayer(polygon);
       expect(map.hasLayer(polygon)).toBeFalsy();


### PR DESCRIPTION
**Describe the change**

Adds a mixin to `L.Map`, which overwrites remove method to ensure the layer's marker is removed if it exists.

**Checklist**

- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made added necessary changes to the TypeScript declaration (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

**Further comments**

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered.
